### PR TITLE
Make marked attacks target all players

### DIFF
--- a/server/prefabs/AttackManager.cpp
+++ b/server/prefabs/AttackManager.cpp
@@ -61,10 +61,14 @@ void AttackManager::newStompAttack() {
 }
 
 void AttackManager::newMarkedAttack() {
-    MarkedAttack* markedAtt = new MarkedAttack(enemyPrefab, playerList);
-    enemyAttackList.push_back(markedAtt);
+    for (int i = 0; i < playerList.size(); i++) {
+        MarkedAttack* markedAtt = new MarkedAttack(enemyPrefab, playerList);
+        enemyAttackList.push_back(markedAtt);
+        NetworkManager::instance().scene.Instantiate(markedAtt);
+        markedAtt->GetComponent<NetTransform>()->position =
+            playerList[i]->GetComponent<NetTransform>()->position;
+    }
     enemyPrefab->GetComponent<EnemyComponent>()->SetState(AttackState::MARK);
-    NetworkManager::instance().scene.Instantiate(markedAtt);
 }
 
 void AttackManager::newSwipeAttack() {

--- a/server/prefabs/AttackManager.cpp
+++ b/server/prefabs/AttackManager.cpp
@@ -62,7 +62,7 @@ void AttackManager::newStompAttack() {
 
 void AttackManager::newMarkedAttack() {
     for (int i = 0; i < playerList.size(); i++) {
-        MarkedAttack* markedAtt = new MarkedAttack(enemyPrefab, playerList);
+        MarkedAttack* markedAtt = new MarkedAttack(enemyPrefab, playerList[i]);
         enemyAttackList.push_back(markedAtt);
         NetworkManager::instance().scene.Instantiate(markedAtt);
         markedAtt->GetComponent<NetTransform>()->position =

--- a/server/prefabs/MarkedAttack.hpp
+++ b/server/prefabs/MarkedAttack.hpp
@@ -7,13 +7,13 @@
 
 class MarkedAttack : public EnemyAttack {
 public:
-    std::vector<Collider*> colliders;
+    Collider* collider;
     float latency;
     float lifetime;
     bool hasExploded = false;
 
-    MarkedAttack(Enemy* owner, std::vector<Player*> playerList);
-    MarkedAttack(Enemy* owner, std::vector<Player*> playerList, int networkId);
+    MarkedAttack(Enemy* owner, Player*);
+    MarkedAttack(Enemy* owner, Player* playerList, int networkId);
 
     void update(float deltaTime) override;
     std::string ToString() override { return "EnemyAttack - Marked"; }

--- a/server/prefabs/MarkedAttack.hpp
+++ b/server/prefabs/MarkedAttack.hpp
@@ -9,10 +9,12 @@ class MarkedAttack : public EnemyAttack {
 public:
     std::vector<Collider*> colliders;
     float latency;
+    float lifetime;
+    bool hasExploded = false;
 
     MarkedAttack(Enemy* owner, std::vector<Player*> playerList);
     MarkedAttack(Enemy* owner, std::vector<Player*> playerList, int networkId);
-    
+
     void update(float deltaTime) override;
     std::string ToString() override { return "EnemyAttack - Marked"; }
 };

--- a/server/prefabs/SkillTraits.hpp
+++ b/server/prefabs/SkillTraits.hpp
@@ -24,7 +24,8 @@
 #define ST_DAMAGE 15
 
 /* MarkedAttack Defines (M) */
-#define LATENCY 4
+#define LATENCY 3.1
+#define M_LIFETIME 3.666
 #define M_DAMAGE 25
 
 /* LaserAttack Defines (L) */

--- a/server/prefabs/enemyAttacks/MarkedAttack.cpp
+++ b/server/prefabs/enemyAttacks/MarkedAttack.cpp
@@ -2,24 +2,16 @@
 #include <iostream>
 #include "CollisionManager.hpp"
 
-MarkedAttack::MarkedAttack(Enemy* owner, std::vector<Player*> playerList)
-    : EnemyAttack(owner) {
-    for (Player* p : playerList) {
-        Collider* attackC = new Collider(this, p->GetComponent<Collider>());
-        colliders.push_back(attackC);
-    }
+MarkedAttack::MarkedAttack(Enemy* owner, Player* player) : EnemyAttack(owner) {
+    collider = new Collider(this, player->GetComponent<Collider>());
     latency = LATENCY;
     lifetime = M_LIFETIME;
     SetDamage(M_DAMAGE);
 }
 
-MarkedAttack::MarkedAttack(Enemy* owner, std::vector<Player*> playerList,
-                           int networkId)
+MarkedAttack::MarkedAttack(Enemy* owner, Player* player, int networkId)
     : EnemyAttack(owner, networkId) {
-    for (Player* p : playerList) {
-        Collider* attackC = new Collider(this, p->GetComponent<Collider>());
-        colliders.push_back(attackC);
-    }
+    collider = new Collider(this, player->GetComponent<Collider>());
     latency = LATENCY;
     lifetime = M_LIFETIME;
     SetDamage(M_DAMAGE);
@@ -29,11 +21,9 @@ void MarkedAttack::update(float deltaTime) {
     latency -= deltaTime;
     lifetime -= deltaTime;
     if (latency < 0 && !hasExploded) {
-        for (Collider* attackC : colliders) {
-            std::vector<GameObject*> players_hit =
-                CollisionManager::instance().moveBossMark(attackC);
-            DealDamage(players_hit);
-        }
+        std::vector<GameObject*> players_hit =
+            CollisionManager::instance().moveBossMark(collider);
+        DealDamage(players_hit);
 
         hasExploded = true;
     }

--- a/server/prefabs/enemyAttacks/MarkedAttack.cpp
+++ b/server/prefabs/enemyAttacks/MarkedAttack.cpp
@@ -9,6 +9,7 @@ MarkedAttack::MarkedAttack(Enemy* owner, std::vector<Player*> playerList)
         colliders.push_back(attackC);
     }
     latency = LATENCY;
+    lifetime = M_LIFETIME;
     SetDamage(M_DAMAGE);
 }
 
@@ -20,18 +21,24 @@ MarkedAttack::MarkedAttack(Enemy* owner, std::vector<Player*> playerList,
         colliders.push_back(attackC);
     }
     latency = LATENCY;
+    lifetime = M_LIFETIME;
     SetDamage(M_DAMAGE);
 }
 
 void MarkedAttack::update(float deltaTime) {
     latency -= deltaTime;
-    if (latency > 0) {
-        return;
+    lifetime -= deltaTime;
+    if (latency < 0 && !hasExploded) {
+        for (Collider* attackC : colliders) {
+            std::vector<GameObject*> players_hit =
+                CollisionManager::instance().moveBossMark(attackC);
+            DealDamage(players_hit);
+        }
+
+        hasExploded = true;
     }
-    for (Collider* attackC : colliders) {
-        std::vector<GameObject*> players_hit =
-            CollisionManager::instance().moveBossMark(attackC);
-        DealDamage(players_hit);
+
+    if (lifetime < 0) {
         exist = false;
     }
 }


### PR DESCRIPTION
Marked attacks now spawn at all player' last known positions. Implemented animations. Delayed damage by 3.1s, and object lifetime by 3.6s